### PR TITLE
- Horses and catapult

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/rogueanimals.dm
+++ b/code/modules/mob/living/simple_animal/rogue/rogueanimals.dm
@@ -266,3 +266,68 @@
 		stop_automated_movement = TRUE
 		Goto(user,move_to_delay)
 		addtimer(CALLBACK(src, PROC_REF(return_action)), 3 SECONDS)
+
+
+
+
+/mob/living/simple_animal/hostile/retaliate/rogue/MobBump(mob/living/M) //CHARGE AND TRAMPLE
+	if(has_buckled_mobs())
+		var/mob/living/carbon/H = buckled_mobs[1]
+		var/obj/item/I = H.get_active_held_item()
+		var/obj/item/U = M.get_active_held_item()
+		var/charge_add = 0
+		var/charge_power = STASTR + rand(5,12)
+		if(H.m_intent == MOVE_INTENT_RUN && dir == get_dir(src, M))
+			if(istype(I, /obj/item/rogueweapon/spear) && H.used_intent.type == SPEAR_THRUST && I.wielded)
+				if(STACON + H.STACON + charge_add >= M.STACON)
+					I.melee_attack_chain(H, M)
+			if(HAS_TRAIT(H, TRAIT_CHARGER))
+				charge_add = 3
+			if(STACON + H.STACON + charge_add > M.STACON)
+				if(STASTR + H.STASTR + charge_add > M.STASTR)
+					M.throw_at(get_edge_target_turf(src, dir),rand(1,3),5,src,TRUE)
+					M.emote("scream")
+					M.Knockdown(rand(15,30))
+					Immobilize(30)
+					if(M.has_buckled_mobs())
+						var/mob/living/carbon/J = M.buckled_mobs[1]
+						M.unbuckle_all_mobs()
+						J.throw_at(get_edge_target_turf(src, dir),rand(1,3),5,src,TRUE)
+						J.emote("scream")
+						J.Knockdown(rand(15,30))
+				else
+					unbuckle_all_mobs()
+					Knockdown(1)
+					H.Knockdown(rand(15,30))
+					Immobilize(30)
+					H.Immobilize(30)
+			if(STACON + H.STACON + charge_add < M.STACON)
+				unbuckle_all_mobs()
+				Knockdown(1)
+				H.Knockdown(rand(15,30))
+				Immobilize(30)
+				H.Immobilize(30)
+			if(STACON + H.STACON + charge_add == M.STACON)
+				H.emote("scream")
+				M.emote("scream")
+				M.Knockdown(rand(15,30))
+				Knockdown(30)
+			if(istype(U, /obj/item/rogueweapon/spear) && M.used_intent.type == SPEAR_THRUST && U.wielded)
+				Immobilize(30)
+				emote("pain")
+				U.melee_attack_chain(M, H)
+				H.Immobilize(30)
+				if(STACON + H.STACON + charge_add <= M.STACON)
+					unbuckle_all_mobs()
+					H.throw_at(get_edge_target_turf(M, dir),1,5,src,TRUE)
+					H.Knockdown(rand(15,30))
+			Immobilize(30)
+			var/playsound = FALSE
+			if(M.apply_damage(charge_power, BRUTE, "chest", M.run_armor_check("chest", "blunt", damage = charge_power)))
+				playsound = TRUE
+			if(playsound)
+				playsound(src, "genblunt", 100, TRUE)
+			emote("aggro")
+			visible_message(span_warning("[H] charges into [M] with [src]!"), span_warning("I charge into [M]!"))
+			return TRUE
+

--- a/modular_helmsguard/code/game/objects/structures/catapult.dm
+++ b/modular_helmsguard/code/game/objects/structures/catapult.dm
@@ -7,12 +7,10 @@
 	density = 1
 	drag_slowdown = 7
 	var/fire_distance = 0
-	var/min_distance = 10
-	var/max_distance = 50
+	var/min_distance = 20
+	var/max_distance = 65
 	var/xoffset = 0
 	var/yoffset = 0
-	var/offset_per_turfs = 20 //Number of turfs to offset from target by 1
-	var/fixed = 0
 	var/travel_time = 50
 	//var/obj/item/boulder/current_projectile = null
 	var/packed = 0
@@ -89,16 +87,16 @@
 					to_chat(user, "<span class='warning'>Someone else is currently using this catapult.</span>")
 					return
 				playsound(src, pick("modular_helmsguard/sound/catapult/aim.ogg", "modular_helmsguard/sound/catapult/aim2.ogg"),  100)
-				user.visible_message("<span class='notice'>([user] tries to turn the [src] to face [direction].</span>")
+				user.visible_message("<span class='notice'>[user] tries to turn the [src] to face [direction].</span>")
 				if(texttodirection != current_direction)
 					busy = 1
 					if(do_after(user, 30, src))
 						dir = texttodirection
-						user.visible_message("<span class='notice'>([user] set the [src]'s firing direction to [direction].</span>",
+						user.visible_message("<span class='notice'>[user] set the [src]'s firing direction to [direction].</span>",
 						"<span class='notice'>You finish adjusting [src]'s firing direction.</span>")
 						busy = 0
 					else
-						user.visible_message("<span class='notice'>(The [src] is already facing [direction].</span>")
+						user.visible_message("<span class='notice'>The [src] is already facing [direction].</span>")
 						busy = 0
 						return
 				else
@@ -114,10 +112,10 @@
 				else
 					busy = 1
 					playsound(src, pick("modular_helmsguard/sound/catapult/aim.ogg", "modular_helmsguard/sound/catapult/aim2.ogg"),  100)
-					user.visible_message("<span class='notice'>([user] begins to set the [src]'s firing distance.</span>")
+					user.visible_message("<span class='notice'>[user] begins to set the [src]'s firing distance.</span>")
 					if(do_after(user, 30, src))
 						fire_distance = distance_input
-						user.visible_message("<span class='notice'>([user] sets the [src] to fire at the distance of [fire_distance] tiles.</span>")
+						user.visible_message("<span class='notice'>[user] sets the [src] to fire at the distance of [fire_distance] tiles.</span>")
 						busy = 0
 					else
 						busy = 0
@@ -296,6 +294,10 @@
 	for(var/mob/M in urange(20, src))
 		if(!M.stat)
 			shake_camera(M, 3, 1)
+	for(var/mob/living/L in range(6, src))
+		if(!L.stat)
+			L.Knockdown(1)
+			L.Jitter(30)
 	for(var/mob/living/player in GLOB.player_list)
 		var/distance = get_dist(player, origin_turf)
 		if(player.stat == DEAD)
@@ -308,10 +310,10 @@
 /obj/projectile/rock_shard
 	name = "rock shard"
 	icon_state = "bullet"
-	damage = 10
+	damage = 15
 	range = 8
 	pass_flags = PASSTABLE | PASSGRILLE
-	armor_penetration = 8
+	armor_penetration = 15
 	damage_type = BRUTE
 	nodamage = FALSE
 	embedchance = 20


### PR DESCRIPTION
- Players can charge and trample other mobs when sprinting while mounted, if there is a spear equipped and wielded with stab intention active, players will automatically deal stab damage upon a successful charge.
- Buffed the catapult's min/max distance, increase shrapnel impact and did some minor cleanup.
