### PR TITLE
Goldface and meister reflavor

### DIFF
--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -43,7 +43,7 @@
 			say("You owe us a debt!")
 			return
 		var/list/choicez = list()
-		if(amt > 32)				// Formerly 10. Helsguard is changing currency base, mind these figures if you revert. Moneyprinting would ensue.
+		if(amt > 32)				// Formerly 10. Helmsguard is changing currency base, mind these figures if you revert. Moneyprinting would ensue.
 			choicez += "GOLD"
 		if(amt > 8)
 			choicez += "SILVER"
@@ -65,9 +65,11 @@
 		if(!Adjacent(user))
 			return
 		if((coin_amt*mod) > amt)
+			say("You exceed your ledger.")
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return
 		if(!SStreasury.withdraw_money_account(coin_amt*mod, H))
+			say("Apologies, the treasury lacks coins. Contact your COINMASTER.")
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return
 		budget2change(coin_amt*mod, user, selection)
@@ -171,7 +173,7 @@
 	else
 		loc.visible_message(span_warning("A horrible scraping sound emanates from the Crown as it does its work..."))
 		if(!has_reported)
-			send_ooc_note("A parasite of the Freefolk is draining a Meister! Location: [location_tag ? location_tag : "Unknown"]", job = list("Grand Duke", "Steward", "Clerk"))
+			send_ooc_note("A parasite of the Freefolk is draining a coinbiter! Location: [location_tag ? location_tag : "Unknown"]", job = list("Grand Duke", "Steward", "Clerk"))
 			has_reported = TRUE
 		playsound(src, 'sound/misc/TheDrill.ogg', 70, TRUE)
 		spawn(100) // The time it takes to complete an interval. If you adjust this, please adjust the sound too. It's 'about' perfect at 100. Anything less It'll start overlapping.

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -1,6 +1,6 @@
 /obj/structure/roguemachine/atm
-	name = "MEISTER"
-	desc = "Stores and withdraws currency for accounts managed by the stewardry of Sundmark."
+	name = "COINBITER"
+	desc = "An elaborate Dwarven contrivance of gears and tubes that vomits or swallows coins to the ticking of clockwork."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "atm"
 	density = FALSE
@@ -17,15 +17,16 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(HAS_TRAIT(user, TRAIT_OUTLAW))
-		to_chat(H, span_warning("The machine rejects you, sensing your status as an outlaw in these lands."))
+		say("My ledger is closed to you, outlaw.")
+		playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)	// Audible notice and protest. Might out someone.
 		return
 	if(drilled)
 		if(HAS_TRAIT(H, TRAIT_NOBLE))
 			if(!HAS_TRAIT(H, TRAIT_COMMIE))
 				var/def_zone = "[(H.active_hand_index == 2) ? "r" : "l" ]_arm"
 				playsound(src, 'sound/items/beartrap.ogg', 100, TRUE)
-				to_chat(user, "<font color='red'>The meister craves my Noble blood!</font>")
-				loc.visible_message(span_warning("The meister snaps onto [H]'s arm!"))
+				to_chat(user, "<font color='red'>The coinbiter craves my Noble blood!</font>")
+				loc.visible_message(span_warning("The coinbiter snaps onto [H]'s arm!"))
 				H.Stun(80)
 				H.apply_damage(50, BRUTE, def_zone)
 				H.emote("agony")
@@ -39,24 +40,24 @@
 			say("Your balance is nothing.")
 			return
 		if(amt < 0)
-			say("Your balance is NEGATIVE.")
+			say("You owe us a debt!")
 			return
 		var/list/choicez = list()
-		if(amt > 10)
+		if(amt > 32)				// Formerly 10. Helsguard is changing currency base, mind these figures if you revert. Moneyprinting would ensue.
 			choicez += "GOLD"
-		if(amt > 5)
+		if(amt > 8)
 			choicez += "SILVER"
 		choicez += "BRONZE"
-		var/selection = input(user, "Make a Selection", src) as null|anything in choicez
+		var/selection = input(user, "Press a Tooth", src) as null|anything in choicez
 		if(!selection)
 			return
 		amt = SStreasury.bank_accounts[H]
 		var/mod = 1
 		if(selection == "GOLD")
-			mod = 10
+			mod = 32
 		if(selection == "SILVER")
-			mod = 5
-		var/coin_amt = input(user, "There is [SStreasury.treasury_value] groschen in the treasury. You may withdraw [floor(amt/mod)] [selection] COINS from your account.", src) as null|num
+			mod = 8
+		var/coin_amt = input(user, "There are [SStreasury.treasury_value] groschen within us. You may ask [floor(amt/mod)] [selection] COINS from your account.", src) as null|num
 		coin_amt = round(coin_amt)
 		if(coin_amt < 1)
 			return
@@ -71,18 +72,19 @@
 			return
 		budget2change(coin_amt*mod, user, selection)
 	else
-		to_chat(user, span_warning("The machine bites my finger."))
+		to_chat(user, span_warning("The gleaming teeth bite my finger."))
 		if(!drilled)
 			icon_state = "atm-b"
 		H.flash_fullscreen("redflash3")
-		playsound(H, 'sound/combat/hits/bladed/genstab (1).ogg', 100, FALSE, -1)
+		playsound(H, 'sound/combat/hits/bladed/genstab (1).ogg', 50, FALSE, -1)	// Quieter stab sound.
 		SStreasury.create_bank_account(H)
 		if(H.mind)
 			var/datum/job/target_job = SSjob.GetJob(H.mind.assigned_role)
 			if(target_job && target_job.noble_income)
 				SStreasury.noble_incomes[H] = target_job.noble_income
+				say("At your service, and your family's.")	// Recognizing nobles and their estate.
 		spawn(5)
-			say("New account created.")
+			say("Your blood now marks my ledger.")
 			playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 
 /*
@@ -125,24 +127,25 @@
 				to_chat(user, "<font color='red'>This one has already been siphoned dry...</font>")
 				return
 			else
-				user.visible_message(span_warning("[user] is mounting the Crown onto the meister!"))
+				user.visible_message(span_warning("[user] is mounting the Crown onto the coinbiter!"))
 				if(do_after(user, 50))
 					if(!drilling)
-						user.visible_message(span_warning("[user] mounts the Crown atop the meister!"))
+						user.visible_message(span_warning("[user] mounts the Crown atop the coinbiter!"))
 						icon_state = "crown_meister"
 						has_reported = FALSE
 						drilling = TRUE
 						drill(src)
 						qdel(P)
-						message_admins("[usr.key] has applied the Crustacean to a MEISTER.")
+						message_admins("[usr.key] has applied the Coveter to a coinbiter.")
 						return
 		else
-			say("No account found. Submit your fingers for inspection.")
+			say("Your mark is not on my ledger. Submit your finger to make your mark.")
+			playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 	return ..()
 
 /obj/structure/roguemachine/atm/examine(mob/user)
 	. += ..()
-	. += span_info("The current tax rate on deposits is [SStreasury.tax_value * 100] percent. Nobles exempt.")
+	. += span_info("A dial shows the current tax on deposits is [SStreasury.tax_value * 100] percent. Nobles exempt.")
 
 
 /obj/structure/roguemachine/atm/proc/drill(obj/structure/roguemachine/atm)
@@ -150,7 +153,7 @@
 		return
 	if(SStreasury.treasury_value <50)
 		new /obj/item/coveter(loc)
-		loc.visible_message(span_warning("The Crown grinds to a halt as the last of the treasury spills from the meister!"))
+		loc.visible_message(span_warning("The Crown grinds to a halt as the last of the treasury spills from the coinbiter!"))
 		playsound(src, 'sound/misc/DrillDone.ogg', 70, TRUE)
 		icon_state = "atm"
 		drilling = FALSE
@@ -158,7 +161,7 @@
 		return
 	if(groschensiphoned >199) // The cap variable for siphoning. 
 		new /obj/item/coveter(loc)
-		loc.visible_message(span_warning("Maximum withdrawal reached! The meister weeps."))
+		loc.visible_message(span_warning("Maximum withdrawal reached! The coinbiter weeps."))
 		playsound(src, 'sound/misc/DrillDone.ogg', 70, TRUE)
 		icon_state = "meister_broken"
 		drilled = TRUE
@@ -172,7 +175,7 @@
 			has_reported = TRUE
 		playsound(src, 'sound/misc/TheDrill.ogg', 70, TRUE)
 		spawn(100) // The time it takes to complete an interval. If you adjust this, please adjust the sound too. It's 'about' perfect at 100. Anything less It'll start overlapping.
-			loc.visible_message(span_warning("The meister spills its bounty!"))
+			loc.visible_message(span_warning("The coinbiter spills its bounty!"))
 			SStreasury.treasury_value -= 20 // Takes from the treasury
 			groschensiphoned += 20
 			budget2change(20, null, "SILVER")
@@ -182,7 +185,7 @@
 
 /obj/structure/roguemachine/atm/attack_right(mob/living/carbon/human/user)
 	if(drilling)
-		to_chat(user,"<font color='yellow'>I begin dismounting the Crown from the meister...</font>" )
+		to_chat(user,"<font color='yellow'>I begin dismounting the Crown from the coinbiter...</font>" )
 		if(do_after(user, 30, src))
 			if(!drilling)
 				return
@@ -195,7 +198,7 @@
 
 /obj/item/coveter
 	name = "Covetous Crown"
-	desc = "A Crown which craves the brow of meisters. The Covetous Crab"
+	desc = "A crown which craves the brow of coinbiters."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "crown_object"
 	force = 10
@@ -260,11 +263,11 @@
 								playsound(src, 'sound/misc/DrillDone.ogg', 70, TRUE)
 								is_active = FALSE
 								to_chat(H,span_info("<font color ='red'>You feel very drained.</font>"))
-								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Coinmaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
 						else
 							is_active = FALSE
 							if(sum)
-								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Coinmaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
 							break
 				if("Slow")
 					is_active = TRUE
@@ -288,11 +291,11 @@
 								drain_effect_fast(H)
 							if(i == needed_cycles)	//Last cycle.
 								is_active = FALSE
-								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Coinmaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
 						else
 							is_active = FALSE
 							if(sum)
-								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Coinmaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
 							break
 				if("Nevermind")
 					return
@@ -303,7 +306,7 @@
 			return
 
 	else
-		to_chat(user,span_info("Their blood is unsoiled by the Duchy's Nervemaster. There is nothing to take."))
+		to_chat(user,span_info("Their blood is unknown to the Coinmaster's ledger. There is nothing to take."))
 		return
 
 /obj/item/coveter/proc/drain_effect_fast(mob/living/carbon/human/H)

--- a/code/modules/roguetown/roguemachine/bathmaster.dm
+++ b/code/modules/roguetown/roguemachine/bathmaster.dm
@@ -207,7 +207,7 @@ SUBSYSTEM_DEF(BMtreasury)
 	priority = FIRE_PRIORITY_WATER_LEVEL
 	var/treasury_value = 0
 	var/multiple_item_penalty = 0.66
-	var/interest_rate = 0.20 // Bit more interest, since it's gonna be much harder for the BMaster to get valuables.
+	var/interest_rate = 0.10 // Down from 20. What were they thinking.
 	var/next_treasury_check = 0
 	var/list/vault_accounting = list()
 

--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -6,8 +6,8 @@
 #define TAB_LOG 6
 
 /obj/structure/roguemachine/steward
-	name = "nerve master"
-	desc = "The stewards most trusted friend."
+	name = "COINMASTER"
+	desc = "Clattering coins and clicking cog-teeth update a clockwork ledger of numbered dials before blood-stained names."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "steward_machine"
 	density = TRUE
@@ -32,7 +32,7 @@
 			update_icon()
 			return
 		else
-			to_chat(user, span_warning("Wrong key."))
+			to_chat(user, span_warning("This key doesn't fit."))
 			return
 	if(istype(P, /obj/item/storage/keyring))
 		var/obj/item/storage/keyring/K = P
@@ -46,10 +46,10 @@
 				(locked) ? (icon_state = "steward_machine_off") : (icon_state = "steward_machine")
 				update_icon()
 				return
-		to_chat(user, span_warning("Wrong key."))
+		to_chat(user, span_warning("None of these keys fit."))
 		return
 	if(istype(P, /obj/item/roguecoin))
-		SStreasury.give_money_treasury(P.get_real_price(), "NERVE MASTER deposit")
+		SStreasury.give_money_treasury(P.get_real_price(), "COINMASTER Deposit")
 		qdel(P)
 		playsound(src, 'sound/misc/coininsert.ogg', 100, FALSE, -1)
 		return
@@ -159,7 +159,7 @@
 					return
 				if(newtax < 1)
 					return
-				SStreasury.give_money_account(newtax, A, "NERVE MASTER")
+				SStreasury.give_money_account(newtax, A, "COINMASTER")
 				break
 	if(href_list["fineaccount"])
 		var/X = locate(href_list["fineaccount"])
@@ -176,7 +176,7 @@
 					return
 				if(newtax < 1)
 					return
-				SStreasury.give_money_account(-newtax, A, "NERVE MASTER")
+				SStreasury.give_money_account(-newtax, A, "COINMASTER")
 				break
 	if(href_list["payroll"])
 		var/list/L = list(GLOB.noble_positions) + list(GLOB.garrison_positions) + list(GLOB.courtier_positions) + list(GLOB.church_positions) + list(GLOB.yeoman_positions) + list(GLOB.peasant_positions) + list(GLOB.youngfolk_positions) + list(GLOB.inquisition_positions)
@@ -200,7 +200,7 @@
 			return
 		for(var/mob/living/carbon/human/H in GLOB.human_list)
 			if(H.job == job_to_pay)
-				SStreasury.give_money_account(amount_to_pay, H, "NERVE MASTER")
+				SStreasury.give_money_account(amount_to_pay, H, "COINMASTER")
 	if(href_list["compact"])
 		compact = !compact
 	return attack_hand(usr)
@@ -233,7 +233,7 @@
 	if(.)
 		return
 	if(locked)
-		to_chat(user, span_warning("It's locked. Of course."))
+		to_chat(user, span_warning("It's locked."))
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	playsound(loc, 'sound/misc/keyboard_enter.ogg', 100, FALSE, -1)
@@ -241,9 +241,9 @@
 	var/contents
 	switch(current_tab)
 		if(TAB_MAIN)
-			contents += "<center>NERVE MASTER<BR>"
+			contents += "<center>COINBITER<BR>"
 			contents += "--------------<BR>"
-			contents += "<a href='?src=\ref[src];switchtab=[TAB_BANK]'>\[Bank\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_BANK]'>\[Ledger\]</a><BR>"
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_STOCK]'>\[Stockpile\]</a><BR>"
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_IMPORT]'>\[Import\]</a><BR>"
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_BOUNTIES]'>\[Bounties\]</a><BR>"
@@ -252,7 +252,7 @@
 		if(TAB_BANK)
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a>"
 			contents += " <a href='?src=\ref[src];compact=1'>\[Compact: [compact? "ENABLED" : "DISABLED"]\]</a><BR>"
-			contents += "<center>Bank<BR>"
+			contents += "<center>Ledger<BR>"
 			contents += "--------------<BR>"
 			contents += "Treasury: [SStreasury.treasury_value]m</center><BR>"
 			contents += "<a href='?src=\ref[src];payroll=1'>\[Pay by Class\]</a><BR><BR>"
@@ -279,7 +279,7 @@
 			contents += "--------------<BR>"
 			if(compact)
 				contents += "Treasury: [SStreasury.treasury_value]m"
-				contents += " / Lord's Tax: [SStreasury.tax_value*100]%"
+				contents += " / Markgraf's Tax: [SStreasury.tax_value*100]%"
 				contents += " / Guild's Tax: [SStreasury.queens_tax*100]%</center><BR>"
 				for(var/datum/roguestock/stockpile/A in SStreasury.stockpile_datums)
 					contents += "<b>[A.name]:</b>"
@@ -290,7 +290,7 @@
 						contents += " <a href='?src=\ref[src];import=\ref[A]'>\[IMP [A.importexport_amt] ([A.get_import_price()])\]</a> <a href='?src=\ref[src];export=\ref[A]'>\[EXP [A.importexport_amt] ([A.get_export_price()])\]</a> <BR>"
 			else
 				contents += "Treasury: [SStreasury.treasury_value]m<BR>"
-				contents += "Lord's Tax: [SStreasury.tax_value*100]%<BR>"
+				contents += "Markgraf's Tax: [SStreasury.tax_value*100]%<BR>"
 				contents += "Guild's Tax: [SStreasury.queens_tax*100]%</center><BR>"
 				for(var/datum/roguestock/stockpile/A in SStreasury.stockpile_datums)
 					contents += "[A.name]<BR>"
@@ -309,14 +309,14 @@
 			contents += "--------------<BR>"
 			if(compact)
 				contents += "Treasury: [SStreasury.treasury_value]m"
-				contents += " / Lord's Tax: [SStreasury.tax_value*100]%"
+				contents += " / Markgraf's Tax: [SStreasury.tax_value*100]%"
 				contents += " / Guild's Tax: [SStreasury.queens_tax*100]%</center><BR>"
 				for(var/datum/roguestock/import/A in SStreasury.stockpile_datums)
 					contents += "<b>[A.name]:</b>"
 					contents += " <a href='?src=\ref[src];import=\ref[A]'>\[Import [A.importexport_amt] ([A.get_import_price()])\]</a><BR><BR>"
 			else
 				contents += "Treasury: [SStreasury.treasury_value]m<BR>"
-				contents += "Lord's Tax: [SStreasury.tax_value*100]%<BR>"
+				contents += "Markgraf's Tax: [SStreasury.tax_value*100]%<BR>"
 				contents += "Guild's Tax: [SStreasury.queens_tax*100]%</center><BR>"
 				for(var/datum/roguestock/import/A in SStreasury.stockpile_datums)
 					contents += "[A.name]<BR>"
@@ -329,7 +329,7 @@
 			contents += "<center>Bounties<BR>"
 			contents += "--------------<BR>"
 			contents += "Treasury: [SStreasury.treasury_value]m<BR>"
-			contents += "Lord's Tax: [SStreasury.tax_value*100]%</center><BR>"
+			contents += "Markgraf's Tax: [SStreasury.tax_value*100]%</center><BR>"
 			for(var/datum/roguestock/bounty/A in SStreasury.stockpile_datums)
 				contents += "[A.name]<BR>"
 				contents += "[A.desc]<BR>"

--- a/code/modules/roguetown/roguestock/bounties.dm
+++ b/code/modules/roguetown/roguestock/bounties.dm
@@ -1,8 +1,8 @@
 /datum/roguestock/bounty/treasure
 	name = "Collectable Treasures"
-	desc = "Treasures are sent to the vault, where they accrue value over time. Payout is a percentage is based on the price of the treasure, with taxes removed from the payout after."
+	desc = "Treasures may be submitted to the vault in return for a percent of its appraised value. The vault will then earn interest for the treasury."
 	item_type = /obj/item
-	payout_price = 10
+	payout_price = 50
 	transport_item = /area/rogue/indoors/town/vault
 	percent_bounty = TRUE
 


### PR DESCRIPTION
Meister / Nervemaster rename and reflavor.

Coinbiter / Coinmaster

Added square root of tax rate * 2 = interest rate on vault deposits, creating a feedback curve. High taxes, high interest earnings. If the peasants are revolting, import some soap.

Created a few more feedback cues to users of the Coinbiter.
Made the whole thing flavored like a clockwork analog computer. Technically possible if you're insane.

User-facing messages from the BITER are user-friendly. Coinmaster messages read a lot more like computer error codes.

Opens the lore possibility to build new Coinbiters using cogs and engineering, rather than these being incomprehensible digital computers.