### PR TITLE
keys and renames

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/cheesemaker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/cheesemaker.dm
@@ -8,7 +8,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/cheesemaker
 
-//	category_tags = list(CTAG_PILGRIM, CTAG_ARTISAN)
+	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)
 
 /datum/outfit/job/roguetown/adventurer/cheesemaker/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -29,6 +29,7 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	mouth = /obj/item/rogueweapon/huntingknife
 	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/roguekey/sund/sund_butcher
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random
 	cloak = /obj/item/clothing/cloak/apron

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/tbutcher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/tbutcher.dm
@@ -21,6 +21,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/roguekey/sund/sund_butcher
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	backpack_contents = list(
 						/obj/item/kitchen/spoon,

--- a/code/modules/jobs/job_types/roguetown/apprentice/apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/apprentice/apprentice.dm
@@ -158,6 +158,7 @@
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		belt = /obj/item/storage/belt/rogue/leather/rope
+		beltr = /obj/item/roguekey/sund/sund_tailor
 		cloak = /obj/item/clothing/cloak/apron/tailor
 		backr = /obj/item/storage/backpack/rogue/satchel
 		backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 2,
@@ -167,6 +168,7 @@
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		belt = /obj/item/storage/belt/rogue/leather/rope
+		beltr = /obj/item/roguekey/sund/sund_tailor
 		armor = /obj/item/clothing/cloak/apron/tailor
 		backr = /obj/item/storage/backpack/rogue/satchel
 		backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 2,
@@ -208,6 +210,7 @@
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		belt = /obj/item/storage/belt/rogue/leather/rope
+		beltr = /obj/item/roguekey/sund/sund_apoth
 		armor = /obj/item/clothing/suit/roguetown/shirt/robe/apprentice
 		backr = /obj/item/storage/backpack/rogue/satchel
 		backpack_contents = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/reagent_containers/glass/alchemical = 1)

--- a/code/modules/jobs/job_types/roguetown/citywatch/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/citywatch/dungeoneer.dm
@@ -1,7 +1,7 @@
 /datum/job/roguetown/dungeoneer
 	title = "Dungeoneer"
 	flag = DUNGEONEER
-	department_flag = CITYWATCH
+	department_flag = COURTIERS
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -11,7 +11,7 @@
 
 	display_order = JDO_DUNGEONEER
 
-	tutorial = "Be you an instrument of sadism for the Markgraf or the guarantor of his merciful hospitality, your duties are a service paid for most handsomely. Perhaps you were promoted from the garrison down to these cells to get your brutality off the town streets where cracked skulls caused outcries, or maybe your soft-hearted lord wanted to be sure his justice was done without malice by a faithful servant. In either case, your little world is the lowest office in the Realm; from it your guests see only hell."
+	tutorial = "Be you an instrument of sadism for the Lord Castellan or the guarantor of his merciful hospitality, your duties are a service paid for most handsomely. Perhaps you were promoted from the garrison down to these cells to get your brutality off the town streets where cracked skulls caused outcries, or maybe your soft-hearted lord wanted to be sure his justice was done without malice by a faithful servant. In either case, your little world is the lowest office in the Realm; from it your guests see only hell."
 	announce_latejoin = FALSE
 	outfit = /datum/outfit/job/roguetown/dungeoneer
 	give_bank_account = 25

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -10,7 +10,7 @@
 	allowed_races = RACES_NO_CONSTRUCT
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = NOBLE_RACES_TYPES
-	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the Markgraf's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy alive- for it is the only thing you can weigh any trust into anymore."
+	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the Castellan's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy alive- for it is the only thing you can weigh any trust into anymore."
 	outfit = /datum/outfit/job/roguetown/steward
 	give_bank_account = 22
 	noble_income = 16
@@ -43,7 +43,7 @@
 	name = "Lord Steward"
 	title = "Lord Steward"
 	f_title = "Lady Stewardess"
-	tutorial = "You are the Markgraf's most trusted advisor, and the steward of his lands.\
+	tutorial = "You are the Castellan's most trusted advisor, and the steward of his lands.\
 				You are responsible for the management of the realm's wealth, overseeing the economy, and ensuring that everything runs smoothly. \
 				You are amongst the few literate subjects in the realm able to assess the value of every items with just a glance."
 	outfit = /datum/outfit/job/roguetown/lord_steward
@@ -102,7 +102,7 @@
 	f_title = "Burgfrau"
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
-	tutorial = "Sworn to defend the Markgraf’s lands, you are both warrior and steward, entrusted with the keep’s defense and the care of its arms.\
+	tutorial = "Sworn to defend the Castellan's lands, you are both warrior and steward, entrusted with the keep’s defense and the care of its arms.\
 	 As Burgmann, you wield blade and shield with skill, but your duties extend beyond the battlefield. You are the quartermaster, \
 	responsible for ensuring the keep is stocked with weapons, armor, and supplies to face whatever threat may arise. You are moderately literate but can't\
 	gauge the value of items as well as the Lord Steward."

--- a/code/modules/jobs/job_types/roguetown/yeomen/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/apothecary.dm
@@ -29,7 +29,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/storage/belt/rogue/surgery_bag/full/physician
-	beltr = /obj/item/storage/keyring/sund/sund_servant
+	beltr = /obj/item/roguekey/sund/sund_apoth
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
@@ -43,9 +43,9 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 4, TRUE)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	H.change_stat("intelligence", 3)
 	H.change_stat("perception", 2)

--- a/code/modules/jobs/job_types/roguetown/yeomen/leatherworker.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/leatherworker.dm
@@ -34,10 +34,10 @@
 	pants = /obj/item/clothing/under/roguetown/tights
 	belt = /obj/item/storage/belt/rogue/leather/cloth
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
-	beltl = /obj/item/rogueweapon/huntingknife/scissors/steel
+	beltl = /obj/item/storage/keyring/sund/sund_tailor
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/needle = 1, /obj/item/natural/hide/cured = 2)
+	backpack_contents = list(/obj/item/needle = 1, /obj/item/natural/hide/cured = 2, /obj/item/rogueweapon/huntingknife/scissors/steel = 1)
 	if(should_wear_femme_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress
 	else if(should_wear_masc_clothes(H))

--- a/modular_helmsguard/code/game/area/sund_areas.dm
+++ b/modular_helmsguard/code/game/area/sund_areas.dm
@@ -88,7 +88,7 @@
 	icon_state = "keep"
 
 /area/rogue/indoors/sund/keep/markgrafs_chambers	// Specific subtypes for notable areas.
-	name = "Markgraf's Chambers"
+	name = "Castellan's Chambers"
 	location_name = "the keep's bedchambers"
 
 /area/rogue/indoors/sund/keep/throne_room

--- a/modular_helmsguard/code/game/objects/items/sund_keys.dm
+++ b/modular_helmsguard/code/game/objects/items/sund_keys.dm
@@ -42,14 +42,14 @@
 // Castle and Retinue keys.
 
 /obj/item/roguekey/sund/sund_ruler
-	name = "Markgraf's key"
+	name = "Castellan's key"
 	desc = "This key is emblazoned with Sundmark's arms in gold."
 	icon_state = "bosskey"
 	lockid = "sund_ruler"
 
 /obj/item/roguekey/sund/sund_family
 	name = "emblazoned key"
-	desc = "This key is emblazoned with the Markgraf's family crest."
+	desc = "This key is emblazoned with the Castellan's family crest."
 	icon_state = "bosskey"
 	lockid = "sund_family"
 


### PR DESCRIPTION
- Dungeoneer reclassed as Courtiers
- Assigned keys to tailors, their apprentices, leatherworkers, cheesemakers and butchers