### PR TITLE
restore and expand on nooses

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -60,7 +60,7 @@
 		qdel(src)
 		return
 	
-	if(amount > DEAD_TO_ZOMBIE_TIME)
+	if(amount > DEAD_TO_ZOMBIE_TIME && !C.hanged)
 		if(is_zombie)
 			var/datum/antagonist/zombie/Z = C.mind.has_antag_datum(/datum/antagonist/zombie)
 			if(Z && !Z.has_turned && !Z.revived && C.stat == DEAD)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -304,3 +304,7 @@
 	var/typing_indicator_timerid
 	/// Current state of our typing indicator. Used for cut overlay, DO NOT RUNTIME ASSIGN OTHER THAN FROM SHOW/CLEAR. Used to absolutely ensure we do not get stuck overlays.
 	var/mutable_appearance/typing_indicator_current
+
+
+	/// for gallows
+	var/hanged = FALSE

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -714,3 +714,30 @@
 	verbage = "assembles"
 	skillcraft = /datum/skill/craft/alchemy
 	craftdiff = 1
+
+
+/datum/crafting_recipe/roguetown/structure/noose
+	name = "noose"
+	result = /obj/structure/noose
+	reqs = list(/obj/item/rope = 1)
+	verbage = "tie"
+	craftsound = 'sound/foley/noose_idle.ogg'
+	ontile = TRUE
+
+/datum/crafting_recipe/roguetown/structure/noose/TurfCheck(mob/user, turf/T)
+	var/turf/checking = get_step_multiz(T, UP)
+	if(!checking)
+		return FALSE
+	if(!isopenturf(checking))
+		return FALSE
+	if(istype(checking,/turf/open/transparent/openspace))
+		return FALSE
+	return TRUE
+
+/datum/crafting_recipe/roguetown/structure/gallows
+	name = "gallows"
+	result = /obj/structure/noose/gallows
+	reqs = list(/obj/item/rope = 1, /obj/item/grown/log/tree/small = 2)
+	verbage = "constructs"
+	craftsound = 'sound/foley/Building-01.ogg'
+	ontile = TRUE

--- a/modular/code/game/objects/gallows.dm
+++ b/modular/code/game/objects/gallows.dm
@@ -18,6 +18,8 @@
 	static_debris = list(/obj/item/rope = 1)
 	breakoutextra = 10 MINUTES
 	buckleverb = "tie"
+	var/offsetx = 0
+	var/offsety = 10
 
 //Map stactic version.
 /obj/structure/noose/gallows
@@ -26,6 +28,8 @@
 	icon_state = "gallows"
 	pixel_y = 0
 	max_integrity = 9999
+	offsetx = 6
+	offsety = 15
 
 /obj/structure/noose/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -64,11 +68,15 @@
 /obj/structure/noose/post_buckle_mob(mob/living/M)
 	if(has_buckled_mobs())
 		START_PROCESSING(SSobj, src)
-		M.set_mob_offsets("bed_buckle", _x = 0, _y = 10)
+		M.set_mob_offsets("bed_buckle", _x = offsetx, _y = offsety)
+		M.setDir(SOUTH)
+		M.hanged = TRUE
 
 /obj/structure/noose/post_unbuckle_mob(mob/living/M)
 	STOP_PROCESSING(SSobj, src)
 	M.reset_offsets("bed_buckle")
+	if(M.hanged)
+		M.hanged = FALSE
 
 /obj/structure/noose/process()
 	if(!has_buckled_mobs())
@@ -85,6 +93,11 @@
 						buckled_mob.adjustOxyLoss(10)
 						if(prob(20))
 							buckled_mob.emote("gasp")
+					if(prob(25))
+						var/flavor_text = list("<span class='danger'>[buckled_mob]'s legs flail for anything to stand on.</span>",\
+												"<span class='danger'>[buckled_mob]'s hands are desperately clutching the noose.</span>",\
+												"<span class='danger'>[buckled_mob]'s limbs sway back and forth with diminishing strength.</span>")
+						buckled_mob.visible_message(pick(flavor_text))
 					playsound(buckled_mob.loc, 'sound/foley/noose_idle.ogg', 30, 1, -3)
 				else
 					if(prob(1))


### PR DESCRIPTION
- Restored noose/gallows mechanics as they were originally coded on Stonekeep
- Added a "hanged" variable that's checked in rotting component to prevent zombification while hanging
- You can now craft nooses with a rope as long as there's a ceiling above you
- You can now craft gallows anywhere with 2 small logs and one rope
