### PR TITLE
Adds missing stuff to Inquisitor

### DIFF
--- a/_maps/map_files/helmsguard/helmsguard2.dmm
+++ b/_maps/map_files/helmsguard/helmsguard2.dmm
@@ -587,6 +587,13 @@
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/speakerinq,
+/obj/item/speakerinq,
+/obj/item/speakerinq,
+/obj/item/listeningdevice,
+/obj/item/listeningdevice,
+/obj/item/listeningdevice,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/basement)
 "awR" = (
@@ -2340,6 +2347,8 @@
 /obj/effect/decal/border/stone{
 	dir = 6
 	},
+/obj/structure/reliquarybox,
+/obj/item/roguekey/psydonkey,
 /turf/open/floor/rogue/churchrough/nosmooth{
 	dir = 8
 	},
@@ -26404,6 +26413,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/church_outside)
+"xSy" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/churchmarble/nosmooth,
+/area/rogue/indoors/town/church/basement)
 "xSK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood{
@@ -126695,7 +126708,7 @@ rpg
 xHR
 mwj
 kSm
-jjd
+xSy
 wju
 kjZ
 cBD

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -211,7 +211,6 @@
 	ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_PERFECT_TRACKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_PURITAN, JOB_TRAIT)
-	r_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate
 	belt = /obj/item/storage/belt/rogue/leather/steel


### PR DESCRIPTION
## About The Pull Request

Inquisitor got his missing reliquary box back, as well as fancy devices to spy on local town's population. Ordinator no longer summons psydon blessed knife on spawn (He had two, now just one). 

## Testing Evidence



## Why It's Good For The Game

Some missing azure inquisitor stuff that wasn't present on helmsguard map
